### PR TITLE
Channel.h: fix missing include

### DIFF
--- a/include/api/softwareEval-backends/Channel.h
+++ b/include/api/softwareEval-backends/Channel.h
@@ -17,8 +17,9 @@
 #ifndef SWEVAL_BACKENDS_CHANNEL_H
 #define SWEVAL_BACKENDS_CHANNEL_H
 
-#include <string>
+#include <cstdint>
 #include <stdbool.h>
+#include <string>
 
 class Channel
 {


### PR DESCRIPTION
This missing include leads to a crash in newer GCC versions (Ubuntu 24.04+)

@danielschloms