### PR TITLE
Expose performance estimator cycle count to etiss at runtime

### DIFF
--- a/include/api/softwareEval-backends/Backend.h
+++ b/include/api/softwareEval-backends/Backend.h
@@ -66,6 +66,7 @@ class Backend
   virtual void initialize(void)=0;
   virtual void execute(void)=0;
   virtual void finalize(void)=0;
+  virtual int64_t getEstimatedCycleCount(void);
 
   void activateStreamToCout(void) { streamer.activate(); };
   void activateStreamToFile(std::string, std::string, std::string, int);

--- a/include/internal/PerformanceEstimator.h
+++ b/include/internal/PerformanceEstimator.h
@@ -35,15 +35,16 @@ class PerformanceEstimator: public Backend
   void initialize(void);
   void execute(void);
   void finalize(void);
+  int64_t getEstimatedCycleCount(void);
 
-  
+
  private:
   PerformanceModel* perfModel_ptr;
 
   // Pointer to channel content
   uint64_t* ch_typeId_ptr;
   uint64_t* ch_instrCnt_ptr;
-  
+
   uint64_t globalInstrCnt = 0;
 };
 

--- a/src/api/Backend.cpp
+++ b/src/api/Backend.cpp
@@ -115,3 +115,8 @@ void Backend::activateStreamToFile(std::string fileNameBase_, std::string outDir
   streamer.activate();
   streamer.setOutFile(fileNameBase_, outDir_, filePostfix_, maxFileSize_);
 }
+
+int64_t Backend::getEstimatedCycleCount(void)
+{
+  return 0;
+}

--- a/src/internal/PerformanceEstimator.cpp
+++ b/src/internal/PerformanceEstimator.cpp
@@ -44,9 +44,9 @@ void PerformanceEstimator::initialize(void)
 void PerformanceEstimator::execute(void)
 {
   int instrCnt = *ch_instrCnt_ptr;
-  
+
   perfModel_ptr->newTraceBlock();
-  
+
   for(int instr_i=0; instr_i < instrCnt; instr_i++)
   {
     perfModel_ptr->callSchedulingFunction(ch_typeId_ptr[instr_i]);
@@ -72,4 +72,9 @@ void PerformanceEstimator::finalize(void)
   std::cout << "-----------------------------------------------------------------------------------------------------------------\n";
 
   streamer.closeStream();
+}
+
+int64_t PerformanceEstimator::getEstimatedCycleCount(void)
+{
+  return perfModel_ptr->getCycleCount();
 }


### PR DESCRIPTION
This is required to access the current cycle count estimation using ETISS/RISC-V MCYCLE CSRs

**Related PRs:**

- SoftwareEvalLib: https://github.com/tum-ei-eda/SoftwareEvalLib/pull/3
- ETISS: Will be created after other are merged
