### PR TITLE
Add TAGE and Perfect branch predictor implementations, fixes in dynamic/static predictor

### DIFF
--- a/libs/externalModels/include/models/common/BimodalBranchPredictModel.h
+++ b/libs/externalModels/include/models/common/BimodalBranchPredictModel.h
@@ -1,0 +1,65 @@
+#ifndef BIMODAL_BRANCH_PREDICT_MODEL_H
+#define BIMODAL_BRANCH_PREDICT_MODEL_H
+
+#include "DynamicBranchPredictModel.h"
+#include <list>
+#include <vector>
+#include <cstdint>
+#include <sstream>
+
+namespace common {
+
+class BimodalPredictor {
+public:
+    BimodalPredictor(uint32_t tableSize);
+
+    bool predict(uint32_t pc) const;
+    void update(uint32_t pc, bool taken);
+
+private:
+    uint32_t calculateIndex(uint32_t pc) const;
+
+    const uint32_t TABLE_SIZE;
+    std::vector<uint8_t> counters;
+};
+
+class BimodalBranchPredictModel : public ConnectorModel {
+public:
+
+    BimodalBranchPredictModel(PerformanceModel* parent_) : ConnectorModel("BimodalBranchPredictModel", parent_), bimodal(131072), btb() {}
+
+    uint64_t* pc_ptr;
+    uint64_t* brTarget_ptr;
+
+    void setPc_p(int pc_p_) { pc_p = pc_p_; }
+    void setPc_np(int pc_np_);
+    uint64_t getPc();
+
+    // Tracing API
+    std::string getInfoHeader();
+    std::string getInfoStream();
+
+private:
+
+    BimodalPredictor bimodal;
+    BranchTargetBuffer btb;
+
+    int pc_p = 0;
+    int pc_np = 0;
+    bool branchInstr = false;
+    int branchInstrPc;
+    int comp_branchAddr;
+    bool pred_taken;
+    int pred_branchAddr;
+
+    std::list<int> pcFifo;
+    const size_t BUFFER_DEPTH = 4096;
+
+    // Status variables for info-print (tracing)
+    bool branch_info = false;
+    bool mispredicted_info = false;
+    uint64_t pc_info = 0;
+};
+
+} // namespace common
+#endif // BIMODAL_BRANCH_PREDICT_MODEL_H

--- a/libs/externalModels/include/models/common/DynamicBranchPredictModel.h
+++ b/libs/externalModels/include/models/common/DynamicBranchPredictModel.h
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include <map>
 #include <list>
+#include <sstream>
 
 // TODO: Check where unsigned int should be used instead of int!
 
@@ -74,7 +75,12 @@ public:
 
     void setPc_p(int);
     void setPc_np(int);
-    int getPc(void);
+    uint64_t getPc(void);
+
+    // Tracing API
+    std::string getInfoHeader(); 
+    std::string getInfoStream();
+    
     
 private:
     int pc_p = 0;
@@ -92,6 +98,11 @@ private:
     
     const int BUFFER_DEPTH;
     std::list<int> pcFifo;
+
+    // Status variables for info-print (tracing)
+    bool branch_info = false;
+    bool mispredicted_info = false;
+    uint64_t pc_info = 0;
 
 };
 

--- a/libs/externalModels/include/models/common/PerfectBranchPredictModel.h
+++ b/libs/externalModels/include/models/common/PerfectBranchPredictModel.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef COMMON_STATIC_BRANCH_PREDICT_MODEL_H
-#define COMMON_STATIC_BRANCH_PREDICT_MODEL_H
+#ifndef COMMON_PERFECT_BRANCH_PREDICT_MODEL_H
+#define COMMON_PERFECT_BRANCH_PREDICT_MODEL_H
 
 #include "PerformanceModel.h"
 
@@ -24,10 +24,10 @@
 
 namespace common{
 
-class StaticBranchPredictModel : public ConnectorModel
+class PerfectBranchPredictModel : public ConnectorModel
 {
 public:
-    StaticBranchPredictModel(PerformanceModel* parent_) : ConnectorModel("StaticBranchPredictModel", parent_) {};
+    PerfectBranchPredictModel(PerformanceModel* parent_) : ConnectorModel("PerfectBranchPredictModel", parent_) {};
 
     uint64_t* pc_ptr;
     uint64_t* brTarget_ptr;
@@ -53,4 +53,4 @@ private:
 
 } //namespace common
   
-#endif //COMMON_STATIC_BRANCH_PREDICT_MODEL_H
+#endif //COMMON_PERFECT_BRANCH_PREDICT_MODEL_H

--- a/libs/externalModels/include/models/common/TAGEPredictor.h
+++ b/libs/externalModels/include/models/common/TAGEPredictor.h
@@ -1,0 +1,60 @@
+#ifndef COMMON_TAGE_PREDICTOR_H
+#define COMMON_TAGE_PREDICTOR_H
+
+
+#include <vector>
+#include <cstdint>
+
+
+class TagePredictor {
+
+public:
+    TagePredictor(int numTables, int tableSize, int bimodalSize, int minHist, int maxHist);
+
+    bool predict(uint32_t pc);
+    void update(uint32_t pc, bool actual);
+
+private:
+    struct Entry {
+        Entry() : ctr(0), tag(0xFFFF), u(0) {}
+
+        int8_t ctr; // 3-bit signed counter (-4 to 3)
+        uint16_t tag; // 16-bit tag
+        uint8_t u; // 2-bit useful bit
+    };
+
+    const int NUM_TABLES;
+    const int TABLE_SIZE;
+    const int BIMODAL_SIZE;
+    const int MAX_HIST;
+    const int INDEX_BITS;
+    const int UBIT_RESET_CNT;
+
+    std::vector<int8_t> bimodalTable;
+    std::vector<std::vector<Entry>> taggedTables;
+    const std::vector<int> historyLengths;
+    const std::vector<int> tagWidths;
+
+    std::vector<bool> globalHistory;
+    uint32_t pathHistory;
+
+    int branchCnt; // for aging
+    bool resetMSB = true; // for alternating which bit to reset during aging
+
+    // status variables
+    int provBank, altBank;
+    int provIdx, altIdx;
+    bool provPred, altPred;
+    bool finalPred;  // The actual prediction use
+
+    // helper functions
+    uint32_t calculateIndex(uint32_t pc, int bank);
+    uint32_t calculateTag(uint32_t pc, int bank);
+
+    std::vector<int> generateHistoryLengths(int numTables, int minHist, int maxHist);
+    std::vector<int> generateTagWidths(int numTables);
+
+
+};
+
+#endif //COMMON_TAGE_PREDICTOR_H

--- a/libs/externalModels/include/models/common/TAGEPredictor.h
+++ b/libs/externalModels/include/models/common/TAGEPredictor.h
@@ -40,6 +40,7 @@ private:
 
     int branchCnt; // for aging
     bool resetMSB = true; // for alternating which bit to reset during aging
+    int useAltOnNewAlloc = 8;
 
     // status variables
     int provBank, altBank;

--- a/libs/externalModels/include/models/common/TageBranchPredictModel.h
+++ b/libs/externalModels/include/models/common/TageBranchPredictModel.h
@@ -1,0 +1,60 @@
+#ifndef TAGE_BRANCH_PREDICT_MODEL_H
+#define TAGE_BRANCH_PREDICT_MODEL_H
+
+#include "TAGEPredictor.h" 
+#include "DynamicBranchPredictModel.h" 
+#include <list>
+#include <map>
+#include <sstream>
+
+namespace common {
+
+struct BranchPredictorModelCfg { 
+    int numTables = 7;
+    int tableSize = 512;
+    int bimodalSize = 4096;
+    int minHist = 5;
+    int maxHist = 130;
+};
+
+class TageBranchPredictModel : public ConnectorModel {
+public:
+
+    //TageBranchPredictModel(PerformanceModel* parent_, const BranchPredictorModelCfg& cfg_) : ConnectorModel("TageBranchPredictModel", parent_), tage(cfg_.numTables, cfg_.tableSize, cfg_.bimodalSize, cfg_.minHist, cfg_.maxHist), btb() {}
+    TageBranchPredictModel(PerformanceModel* parent_) : ConnectorModel("TageBranchPredictModel", parent_), tage(7, 512, 4096, 5, 130), btb() {}
+
+    uint64_t* pc_ptr;
+    uint64_t* brTarget_ptr;
+
+    void setPc_p(int pc_p_) { pc_p = pc_p_; }
+    void setPc_np(int pc_np_);
+    uint64_t getPc();
+
+    // Tracing API
+    std::string getInfoHeader(); 
+    std::string getInfoStream();
+
+private:
+
+    TagePredictor tage;
+    BranchTargetBuffer btb;
+
+    int pc_p = 0;
+    int pc_np = 0;
+    bool branchInstr = false;
+    int branchInstrPc;
+    int comp_branchAddr;
+    bool pred_taken;
+    int pred_branchAddr;
+
+    std::list<int> pcFifo;
+    const size_t BUFFER_DEPTH = 1024;    
+
+    // Status variables for info-print (tracing)
+    bool branch_info = false;
+    bool mispredicted_info = false;
+    uint64_t pc_info = 0;
+};
+
+} // namespace common
+#endif // TAGE_BRANCH_PREDICT_MODEL_H

--- a/libs/externalModels/src/common/BimodalBranchPredictModel.cpp
+++ b/libs/externalModels/src/common/BimodalBranchPredictModel.cpp
@@ -1,0 +1,105 @@
+#include "models/common/BimodalBranchPredictModel.h"
+
+namespace common {
+
+BimodalPredictor::BimodalPredictor(uint32_t tableSize)
+    : TABLE_SIZE(tableSize), counters(tableSize, 2) // Init: weakly taken (10)
+{}
+
+bool BimodalPredictor::predict(uint32_t pc) const {
+    return counters[calculateIndex(pc)] >= 2; // 2,3 = taken; 0,1 = not taken
+}
+
+void BimodalPredictor::update(uint32_t pc, bool taken) {
+    uint32_t idx = calculateIndex(pc);
+    if (taken) {
+        if (counters[idx] < 3) counters[idx]++;
+    } else {
+        if (counters[idx] > 0) counters[idx]--;
+    }
+}
+
+uint32_t BimodalPredictor::calculateIndex(uint32_t pc) const {
+    return (pc >> 2) % TABLE_SIZE; // >>2 due to 4-Byte-Alignment
+}
+
+void BimodalBranchPredictModel::setPc_np(int pc_np_) {
+    branchInstr = true;
+    branchInstrPc = pc_ptr[getInstrIndex()];
+    comp_branchAddr = brTarget_ptr[getInstrIndex()];
+    pc_np = pc_np_;
+
+    bool entryExists = false;
+    for(int entry : pcFifo) {
+        if(entry == branchInstrPc) { entryExists = true; break; }
+    }
+
+    if(!entryExists) {
+        if(pcFifo.size() < BUFFER_DEPTH) {
+            btb.createEntry(branchInstrPc);
+        }
+        else {
+            int removePc = pcFifo.front();
+            pcFifo.pop_front();
+            btb.replaceEntry(branchInstrPc, removePc);
+        }
+        pcFifo.push_back(branchInstrPc);
+    }
+
+    pred_taken = bimodal.predict(branchInstrPc);
+    pred_branchAddr = btb.getPrediction(branchInstrPc);
+}
+
+uint64_t BimodalBranchPredictModel::getPc() {
+
+    if(!branchInstr) return pc_p;
+
+    branch_info = true;
+    mispredicted_info = false;
+    pc_info = pc_p;
+    branchInstr = false;
+    int curPc = pc_ptr[getInstrIndex()];
+
+    bool taken = (curPc == comp_branchAddr);
+
+    mispredicted_info = pred_taken != taken;
+
+    bimodal.update(branchInstrPc, taken);
+
+    if(curPc == comp_branchAddr) {
+        btb.update(branchInstrPc, comp_branchAddr);
+    }
+
+    if(pred_taken && (curPc == pred_branchAddr)) {
+        return pc_p;
+    }
+    if(!pred_taken && !taken) {
+        return pc_p;
+    }
+
+    pc_info = pc_np;
+    return pc_np;
+}
+
+
+std::string BimodalBranchPredictModel::getInfoHeader()
+{
+  std::stringstream ret_strs;
+  ret_strs << "br:is_branch";
+  ret_strs << "," << "br:mispredict";
+  ret_strs << "," << "br:btb_size";
+  return ret_strs.str();
+}
+
+std::string BimodalBranchPredictModel::getInfoStream()
+{
+  std::stringstream ret_strs;
+  ret_strs << branch_info;
+  ret_strs << "," << mispredicted_info;
+  ret_strs << "," << btb.getSize();
+  branch_info = false;
+  mispredicted_info = false;
+  return ret_strs.str();
+}
+
+} // namespace common

--- a/libs/externalModels/src/common/CMakeLists.txt
+++ b/libs/externalModels/src/common/CMakeLists.txt
@@ -4,4 +4,5 @@ TARGET_SOURCES(SWEVAL_BACKENDS_LIB PRIVATE
     TAGEPredictor.cpp
     TageBranchPredictModel.cpp
     PerfectBranchPredictModel.cpp
+    BimodalBranchPredictModel.cpp
 )

--- a/libs/externalModels/src/common/CMakeLists.txt
+++ b/libs/externalModels/src/common/CMakeLists.txt
@@ -1,4 +1,7 @@
 TARGET_SOURCES(SWEVAL_BACKENDS_LIB PRIVATE
     StaticBranchPredictModel.cpp
     DynamicBranchPredictModel.cpp
+    TAGEPredictor.cpp
+    TageBranchPredictModel.cpp
+    PerfectBranchPredictModel.cpp
 )

--- a/libs/externalModels/src/common/DynamicBranchPredictModel.cpp
+++ b/libs/externalModels/src/common/DynamicBranchPredictModel.cpp
@@ -37,10 +37,10 @@ void PredictFsm::update(bool taken)
   case STRONG_NOT_TAKEN: state = taken ? WEAK_NOT_TAKEN : STRONG_NOT_TAKEN;
     break;
 
-  case WEAK_NOT_TAKEN: state = taken ? STRONG_TAKEN : STRONG_NOT_TAKEN;
+  case WEAK_NOT_TAKEN: state = taken ? WEAK_TAKEN : STRONG_NOT_TAKEN;
     break;
 
-  case WEAK_TAKEN: state = taken ? STRONG_TAKEN : STRONG_NOT_TAKEN;
+  case WEAK_TAKEN: state = taken ? STRONG_TAKEN : WEAK_NOT_TAKEN;
     break;
 
   case STRONG_TAKEN: state = taken ? STRONG_TAKEN : WEAK_TAKEN;
@@ -152,6 +152,7 @@ void DynamicBranchPredictModel::setPc_p(int pc_p_)
 
 void DynamicBranchPredictModel::setPc_np(int pc_np_)
 {
+  pc_np = pc_np_;
   branchInstr = true;
   branchInstrPc = pc_ptr[getInstrIndex()];
   comp_branchAddr = brTarget_ptr[getInstrIndex()];
@@ -189,17 +190,21 @@ void DynamicBranchPredictModel::setPc_np(int pc_np_)
   
 }
 
-int DynamicBranchPredictModel::getPc()
+uint64_t DynamicBranchPredictModel::getPc()
 {
   if(!branchInstr)
   {
     return pc_p;
   }
 
+  branch_info = true;
+  mispredicted_info = false;
+  pc_info = pc_p;
   branchInstr = false;
   
   int curPc = pc_ptr[getInstrIndex()];
-  bool taken = (curPc == pred_branchAddr) | (curPc == comp_branchAddr);
+
+  bool taken = (curPc == comp_branchAddr);
 
   bht.update(branchInstrPc, taken);
   if(curPc == comp_branchAddr)
@@ -216,8 +221,28 @@ int DynamicBranchPredictModel::getPc()
     return pc_p;
   }
 
+  mispredicted_info = true;
+  pc_info = pc_np;
   return pc_np;
   
+}
+
+std::string DynamicBranchPredictModel::getInfoHeader()
+{
+  std::stringstream ret_strs;
+  ret_strs << "br:is_branch";
+  ret_strs << "," << "br:mispredict";
+  return ret_strs.str();
+}
+
+std::string DynamicBranchPredictModel::getInfoStream()
+{
+  std::stringstream ret_strs;
+  ret_strs << branch_info;
+  ret_strs << "," << mispredicted_info;
+  branch_info = false;
+  mispredicted_info = false;
+  return ret_strs.str();
 }
 
 } // namespace common

--- a/libs/externalModels/src/common/PerfectBranchPredictModel.cpp
+++ b/libs/externalModels/src/common/PerfectBranchPredictModel.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "models/common/StaticBranchPredictModel.h"
+#include "models/common/PerfectBranchPredictModel.h"
 
 #include <cstdint>
 #include <string>
@@ -22,21 +22,21 @@
 
 namespace common{
 
-void StaticBranchPredictModel::setPc_p(uint64_t pc_p_)
+void PerfectBranchPredictModel::setPc_p(uint64_t pc_p_)
 {
   // Every instruction calls setPc_p, so assume it is not a branch
   branchInstr = false;
   pc_p = pc_p_;
 }
 
-void StaticBranchPredictModel::setPc_np(uint64_t pc_np_)
+void PerfectBranchPredictModel::setPc_np(uint64_t pc_np_)
 {
   pc_np = pc_np_;
   branchInstr = true;
   branchTarget = brTarget_ptr[getInstrIndex()];
 }
 
-uint64_t StaticBranchPredictModel::getPc(void)
+uint64_t PerfectBranchPredictModel::getPc(void)
 {
   if(!branchInstr)
   {
@@ -47,31 +47,22 @@ uint64_t StaticBranchPredictModel::getPc(void)
   mispredicted_info = false;
   pc_info = pc_p;
 
-  // Always predict branch-not-taken
-  if(pc_ptr[getInstrIndex()] == branchTarget)
-  {
-    mispredicted_info = true;
-    pc_info = pc_np;
-    return pc_np;
-  }
   return pc_p;
 }
 
-std::string StaticBranchPredictModel::getInfoHeader()
+std::string PerfectBranchPredictModel::getInfoHeader()
 {
   std::stringstream ret_strs;
   ret_strs << "br:is_branch";
   ret_strs << "," << "br:mispredict";
-  ret_strs << "," << "br:pc_avail";
   return ret_strs.str();
 }
 
-std::string StaticBranchPredictModel::getInfoStream()
+std::string PerfectBranchPredictModel::getInfoStream()
 {
   std::stringstream ret_strs;
   ret_strs << branch_info;
   ret_strs << "," << mispredicted_info;
-  ret_strs << "," << pc_info;
   branch_info = false;
   mispredicted_info = false;
   return ret_strs.str();

--- a/libs/externalModels/src/common/StaticBranchPredictModel.cpp
+++ b/libs/externalModels/src/common/StaticBranchPredictModel.cpp
@@ -46,6 +46,7 @@ uint64_t StaticBranchPredictModel::getPc(void)
   branch_info = true;
   mispredicted_info = false;
   pc_info = pc_p;
+  branchInstr = false;
 
   // Always predict branch-not-taken
   if(pc_ptr[getInstrIndex()] == branchTarget)

--- a/libs/externalModels/src/common/TAGEPredictor.cpp
+++ b/libs/externalModels/src/common/TAGEPredictor.cpp
@@ -93,11 +93,12 @@ bool TagePredictor::predict(uint32_t pc) {
     }
 
     // If provider is new (u=0) and weak, use alternate prediction
-    finalPred = provPred;  // Default to provider prediction
+    finalPred = provPred;
     if (provBank != -1) {
         Entry& e = taggedTables[provBank][provIdx];
-        if (e.u == 0 && (e.ctr == 0 || e.ctr == -1)) {
-            finalPred = altPred;  // Use alternate prediction for newly allocated entries
+        bool newlyAllocated = (e.u == 0 && (e.ctr == 0 || e.ctr == -1));
+        if (newlyAllocated && useAltOnNewAlloc >= 8) {
+            finalPred = altPred;
         }
     }
 
@@ -117,6 +118,8 @@ void TagePredictor::update(uint32_t pc, bool actual) {
     } else {
         // update provider entry
         Entry& e = taggedTables[provBank][provIdx];
+        bool newlyAllocated = (e.u == 0 && (e.ctr == 0 || e.ctr == -1));
+        
         if (actual && e.ctr < 3) {
             e.ctr++;
         } else if (!actual && e.ctr > -4) {
@@ -131,6 +134,14 @@ void TagePredictor::update(uint32_t pc, bool actual) {
                 if (e.u > 0) e.u--;
             }
         }
+
+        // update global useAltOnNewAlloc counter
+        
+        if (newlyAllocated && provPred != altPred) {
+            if (altPred == actual && useAltOnNewAlloc < 15) useAltOnNewAlloc++;
+            else if (altPred != actual && useAltOnNewAlloc > 0) useAltOnNewAlloc--;
+        }
+        
     }
 
     // Allocation: If mispredicted, try to allocate in longer history bank
@@ -144,8 +155,6 @@ void TagePredictor::update(uint32_t pc, bool actual) {
                     allocBank = i;
                 } else if (rand() % 3 == 0) {
                     allocBank = i;
-                    break;
-                } else {
                     break;
                 }
             }

--- a/libs/externalModels/src/common/TAGEPredictor.cpp
+++ b/libs/externalModels/src/common/TAGEPredictor.cpp
@@ -1,0 +1,190 @@
+#include "models/common/TAGEPredictor.h"
+#include "cmath"
+#include <cstdlib>
+
+// helper function to generate geometric history lengths
+std::vector<int> TagePredictor::generateHistoryLengths(int numTables, int minHist, int maxHist) {
+    std::vector<int> lengths(numTables);
+    for (int i = 0; i < numTables; i++) {
+        lengths[i] = (int)(minHist * pow((double)maxHist / minHist, (double)i / (numTables - 1)) + 0.5);
+    }
+    return lengths;
+}
+
+// helper function to generate per-table tag widths (paper Table 2: 9-bit for T1/T2, increasing by 1 every 2 tables)
+std::vector<int> TagePredictor::generateTagWidths(int numTables) {
+    std::vector<int> widths(numTables);
+    for (int i = 0; i < numTables; i++) {
+        widths[i] = 9 + (i / 2);
+    }
+    return widths;
+}
+
+TagePredictor::TagePredictor(int numTables, int tableSize, int bimodalSize, int minHist, int maxHist) :
+    NUM_TABLES(numTables),
+    TABLE_SIZE(tableSize), 
+    BIMODAL_SIZE(bimodalSize), 
+    MAX_HIST(maxHist),
+    INDEX_BITS((int)log2(tableSize)),
+    UBIT_RESET_CNT(256 * 1024), // for example, reset useful bits every 256K branches
+    bimodalTable(BIMODAL_SIZE, 2), // initialized to "weakly taken"
+    taggedTables(NUM_TABLES, std::vector<Entry>(TABLE_SIZE)),
+    historyLengths(generateHistoryLengths(numTables, minHist, maxHist)),
+    tagWidths(generateTagWidths(numTables)),
+    globalHistory(MAX_HIST, false),
+    pathHistory(0),
+    branchCnt(0),
+    resetMSB(true)
+{
+}
+
+uint32_t TagePredictor::calculateIndex(uint32_t pc, int bank) {
+    int histLen = historyLengths[bank];
+    uint32_t hash = pc;
+    for (int i = 0; i < histLen; i++) {
+        hash ^= (globalHistory[i] << (i % 9)); // Simple XOR folding
+    }
+    hash ^= (pathHistory << bank);
+    return hash % TABLE_SIZE;
+}
+
+uint32_t TagePredictor::calculateTag(uint32_t pc, int bank) {
+    int histLen = historyLengths[bank];
+    int width = tagWidths[bank]; // per-table tag width (9-bit for T1/T2, increasing)
+    uint32_t tag = pc ^ (pc >> 4);
+    for (int i = 0; i < histLen; i++) {
+        tag ^= (globalHistory[i] << ((i * 7 + bank) % 10));
+    }
+    return tag & ((1 << width) - 1);
+}
+
+bool TagePredictor::predict(uint32_t pc) {
+    provBank = -1; // -1 means we will use T0 at the end
+    altBank = -1;
+
+    // Search for "Longest Match" (Provider) and "Second Longest Match" (Alternate)
+    for (int i = NUM_TABLES - 1; i >= 0; i--) { // From T7 (long) to T1 (short)
+        uint32_t idx = calculateIndex(pc, i);
+        uint32_t tag = calculateTag(pc, i);
+
+        if (taggedTables[i][idx].tag == tag) {
+            if (provBank == -1) {
+                provBank = i;
+                provIdx = idx;
+            } else if (altBank == -1) {
+                altBank = i;
+                altIdx = idx;
+                break;
+            }
+        }
+    }
+
+    // Get predictions
+    if (provBank == -1) {
+        provPred = (bimodalTable[pc % BIMODAL_SIZE] >= 2);
+    } else {
+        provPred = (taggedTables[provBank][provIdx].ctr >= 0);
+    }   
+
+    if (altBank == -1) {
+        altPred = (bimodalTable[pc % BIMODAL_SIZE] >= 2);
+    } else {
+        altPred = (taggedTables[altBank][altIdx].ctr >= 0);
+    }
+
+    // If provider is new (u=0) and weak, use alternate prediction
+    finalPred = provPred;  // Default to provider prediction
+    if (provBank != -1) {
+        Entry& e = taggedTables[provBank][provIdx];
+        if (e.u == 0 && (e.ctr == 0 || e.ctr == -1)) {
+            finalPred = altPred;  // Use alternate prediction for newly allocated entries
+        }
+    }
+
+    return finalPred;
+}
+
+void TagePredictor::update(uint32_t pc, bool actual) {
+    // Update provider
+    if (provBank == -1) {
+        // no provider, update bimodal
+        int8_t& c = bimodalTable[pc % BIMODAL_SIZE];
+        if (actual && c < 3) {
+            c++;
+        } else if (!actual && c > 0) {
+            c--;
+        }
+    } else {
+        // update provider entry
+        Entry& e = taggedTables[provBank][provIdx];
+        if (actual && e.ctr < 3) {
+            e.ctr++;
+        } else if (!actual && e.ctr > -4) {
+            e.ctr--;
+        }
+
+        // update usefull bit
+        if (finalPred != altPred) {
+            if (finalPred == actual) {
+                if (e.u < 3) e.u++;
+            } else {
+                if (e.u > 0) e.u--;
+            }
+        }
+    }
+
+    // Allocation: If mispredicted, try to allocate in longer history bank
+    if (finalPred != actual && provBank < NUM_TABLES - 1) {
+        // prefer shorter history with ~2x probability
+        int allocBank = -1;
+        for (int i = provBank + 1; i < NUM_TABLES; i++) {
+            uint32_t idx = calculateIndex(pc, i);
+            if (taggedTables[i][idx].u == 0) {
+                if (allocBank == -1) {
+                    allocBank = i;
+                } else if (rand() % 3 == 0) {
+                    allocBank = i;
+                    break;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        if (allocBank != -1) {
+            uint32_t idx = calculateIndex(pc, allocBank);
+            taggedTables[allocBank][idx].tag = calculateTag(pc, allocBank);
+            taggedTables[allocBank][idx].ctr = (actual) ? 0 : -1;
+            taggedTables[allocBank][idx].u = 0;
+        } else {
+            // Aging: no free entry found, decrement all useful bits
+            for (int i = provBank + 1; i < NUM_TABLES; i++) {
+                uint32_t idx = calculateIndex(pc, i);
+                if (taggedTables[i][idx].u > 0) taggedTables[i][idx].u--;
+            }
+        }
+    }
+
+    // Update global and path history
+    globalHistory.insert(globalHistory.begin(), actual);
+    globalHistory.pop_back();
+    // Use bit 2 of PC (bit 0 is always 0 for RISC-V 4-byte aligned instructions)
+    pathHistory = ((pathHistory << 1) | ((pc >> 2) & 1)) & 0xFFFF; // 16-bit mask
+
+    // Aging: every UBIT_RESET_CNT updates, reset all useful bits
+    branchCnt++;
+
+    if (branchCnt >= UBIT_RESET_CNT) {
+        branchCnt = 0;
+        for (int i = 0; i < NUM_TABLES; i++) {
+            for (int j = 0; j < TABLE_SIZE; j++) {
+                if (resetMSB) taggedTables[i][j].u &= 1; // clear MSB
+                else taggedTables[i][j].u &= 2;          // clear LSB
+            }
+        }
+        resetMSB = !resetMSB;
+    }
+
+}
+
+

--- a/libs/externalModels/src/common/TageBranchPredictModel.cpp
+++ b/libs/externalModels/src/common/TageBranchPredictModel.cpp
@@ -1,0 +1,84 @@
+#include "models/common/TageBranchPredictModel.h"
+
+namespace common {
+
+void TageBranchPredictModel::setPc_np(int pc_np_) {
+    branchInstr = true;
+    branchInstrPc = pc_ptr[getInstrIndex()];
+    comp_branchAddr = brTarget_ptr[getInstrIndex()];
+    pc_np = pc_np_;
+
+    bool entryExists = false;
+    for(int entry : pcFifo) {
+        if(entry == branchInstrPc) { entryExists = true; break; }
+    }
+
+    if(!entryExists) {
+        if(pcFifo.size() < BUFFER_DEPTH) {
+            btb.createEntry(branchInstrPc);
+        }
+        else {
+            int removePc = pcFifo.front();
+            pcFifo.pop_front();
+            btb.replaceEntry(branchInstrPc, removePc);
+        }
+        pcFifo.push_back(branchInstrPc);
+    
+    }
+
+    pred_taken = tage.predict(branchInstrPc);
+    pred_branchAddr = btb.getPrediction(branchInstrPc);
+}
+
+uint64_t TageBranchPredictModel::getPc() {
+
+    if(!branchInstr) return pc_p;
+
+    branch_info = true;
+    mispredicted_info = false;
+    pc_info = pc_p;
+    branchInstr = false;
+    int curPc = pc_ptr[getInstrIndex()];
+    
+    bool taken = (curPc == comp_branchAddr);
+
+    tage.update(branchInstrPc, taken);
+
+    if(curPc == comp_branchAddr) {
+        btb.update(branchInstrPc, comp_branchAddr);
+    }
+
+    if(pred_taken && (curPc == pred_branchAddr)) {
+        return pc_p;
+    }
+    if(!pred_taken && !taken) {
+        return pc_p;
+    }
+
+    mispredicted_info = true;
+    pc_info = pc_np;
+    return pc_np;
+}
+
+
+std::string TageBranchPredictModel::getInfoHeader()
+{
+  std::stringstream ret_strs;
+  ret_strs << "br:is_branch";
+  ret_strs << "," << "br:mispredict";
+  return ret_strs.str();
+}
+
+std::string TageBranchPredictModel::getInfoStream()
+{
+  std::stringstream ret_strs;
+  ret_strs << branch_info;
+  ret_strs << "," << mispredicted_info;
+  branch_info = false;
+  mispredicted_info = false;
+  return ret_strs.str();
+}
+
+
+
+} // namespace common

--- a/libs/externalModels/src/common/TageBranchPredictModel.cpp
+++ b/libs/externalModels/src/common/TageBranchPredictModel.cpp
@@ -42,6 +42,8 @@ uint64_t TageBranchPredictModel::getPc() {
     
     bool taken = (curPc == comp_branchAddr);
 
+    mispredicted_info = pred_taken != taken;
+
     tage.update(branchInstrPc, taken);
 
     if(curPc == comp_branchAddr) {
@@ -55,7 +57,6 @@ uint64_t TageBranchPredictModel::getPc() {
         return pc_p;
     }
 
-    mispredicted_info = true;
     pc_info = pc_np;
     return pc_np;
 }


### PR DESCRIPTION
## Summary
Adds threenew branch predictor implementations and fixes issues with the dynamic branch predictor and tracing API of the static branch predictor.

## Changes
- **TAGE Predictor**: Implements a TAGE (TAgged GEometric history length) predictor
- **Perfect Predictor**: Implements a "perfect" branch predictor as an
  oracle/baseline reference implementation, used to compare prediction
  accuracy against other predictors.
- **Bimodal Predictor**: Implements a Bimodal predictor
- **Dynamic Predictor**: 
  - Fixes the update logic of the PredictFSM.
  - Fixes that pc_np has never been set.
  - Changes taken logic: only if the pc equals the branch target adress, the branch is evaluated as taken.
- **Tracing API Fixes**:
  - Fixes a bug in the tracing API of the static branch predictor.
  - Adds the tracing API to the dynamic branch predictor.